### PR TITLE
Merge top_k and top_p activation plotting into a unified interface

### DIFF
--- a/comma_importance.py
+++ b/comma_importance.py
@@ -26,7 +26,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 from utils.circuit_analysis import get_logit_diff
 from utils.tokenwise_ablation import (
-    compute_ablation_modified_metric,
+    compute_ablation_modified_loss,
     load_directions,
     get_random_directions,
     get_zeroed_dir_vector,
@@ -40,7 +40,7 @@ from utils.datasets import (
     mask_positions,
     construct_exclude_list,
 )
-from utils.neuroscope import plot_topk_onesided
+from utils.neuroscope import plot_top_onesided
 from utils.store import ResultsFile
 
 # %%
@@ -83,11 +83,10 @@ comma_mean_values = get_layerwise_token_mean_activations(
 # %%
 data_loader = exp_data.get_dataloaders(batch_size=1)[SPLIT]
 print(data_loader.name, data_loader.batch_size)
-losses = compute_ablation_modified_metric(
+losses = compute_ablation_modified_loss(
     model,
     data_loader,
     cached_means=comma_mean_values,
-    metric="loss",
     device=device,
     overwrite=OVERWRITE,
 )
@@ -142,7 +141,7 @@ loss_mask |= orig_loss_filter
 # %%
 ablated_loss_diffs = torch.where(loss_mask, 0, losses[1])
 # %%
-plot_topk_onesided(
+plot_top_onesided(
     ablated_loss_diffs,
     data_loader,
     model,

--- a/period_ablation_experiments.py
+++ b/period_ablation_experiments.py
@@ -47,7 +47,7 @@ from utils.tokenwise_ablation import (
     get_layerwise_token_mean_activations,
 )
 from utils.datasets import OWTData, PileFullData, PileSplittedData
-from utils.neuroscope import plot_topk_onesided, plot_top_p
+from utils.neuroscope import plot_top_onesided
 
 # %%
 device = torch.device("cuda")
@@ -92,34 +92,25 @@ losses = compute_ablation_modified_loss(
 ablated_loss_diffs = losses[1]
 losses.shape
 # %%
-plot_topk_onesided(
-    ablated_loss_diffs,
-    smaller_data_loader,
-    model,
-    k=10
-)
+plot_top_onesided(ablated_loss_diffs, smaller_data_loader, model, k=10)
 # %%
-plot_top_p(
-    ablated_loss_diffs.unsqueeze(-1),
+plot_top_onesided(
+    ablated_loss_diffs,
     smaller_data_loader,
     model,
     k=10,
     p=0.1,
     window_size=50,
 )
-
-# %%
-ablated_loss_diffs.unsqueeze(-1).shape
-
 # %%
 ablated_loss_diffs[0][15:30]
 
 # %%
 batch = next(iter(data_loader))
-batch['tokens'][0][15:30]
+batch["tokens"][0][15:30]
 
 # %%
-model.to_str_tokens(batch['tokens'][0][15:30])
+model.to_str_tokens(batch["tokens"][0][15:30])
 
 # %%
 exp_data = OWTData.from_model(model)
@@ -128,6 +119,6 @@ exp_data = OWTData.from_model(model)
 ds = exp_data.get_datasets()
 
 # %%
-ds['train'][1]['text']
+ds["train"][1]["text"]
 
 # %%


### PR DESCRIPTION
# Description

Now top k and top p plotting are both accessible from `plot_top_onesided` and `plot_top_activations` depending on the given arguments for k, p.

Fixes issue where plot_top_p was broken and not up to date.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
- [x] I have followed the style guide below

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

# Style guide
- My code follows the [Black](https://pypi.org/project/black/) format
- I have minimised type warnings from [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
- Cull any redundant and unused code
- Cache results of slow operations in as flexible of a format as possible, in a flat structure inside results/cache and the file name contains all necessary identifying information (such as model name and dataset used) to avoid accidental overwriting.
- Use intuitive abstractions, making clear the public entrypoints to a given class
- Function and variable names should be long enough to be descriptive


