### PR TITLE
Cross entropy loss over vocab subset

### DIFF
--- a/comma_importance.py
+++ b/comma_importance.py
@@ -323,6 +323,15 @@ with minimal_hook:
         prompt, prompt_answer, model, top_k=top_k, prepend_space_to_answer=False
     )
 # %%
+prompt_file = ResultsFile(
+    "prompt",
+    model=MODEL_NAME,
+    data=data_loader.name,
+    result_type="cache",
+    extension="txt",
+)
+prompt_file.save(prompt)
+# %%
 """
 TODO:
 * Debug Zeldovich pancakes snippet

--- a/comma_importance.py
+++ b/comma_importance.py
@@ -65,6 +65,32 @@ TOKEN_ID = model.to_single_token(TOKEN)
 assert isinstance(TOKEN_ID, int)
 print(TOKEN_ID)
 # %%
+exclude_regex = [
+    r"\]",
+    r"\[",
+    r"\(",
+    r"\)",
+    r",",
+    r":",
+    r";",
+    r"`",
+    r"'",
+    r"\.",
+    r"!",
+    r"\?",
+    r"“",
+    r"{",
+    r"}",
+    r"\\",
+    r"/",
+    r"^g$",
+    r"[0-9]",
+]
+exclude_list = construct_exclude_list(model, exclude_regex)
+vocab_mask = torch.ones(model.vocab_size, dtype=torch.bool)
+vocab_mask[exclude_list] = False
+print(len(exclude_list), vocab_mask.sum().item())
+# %%
 exp_data = PileSplittedData.from_model(
     model,
     name=NAME,
@@ -87,6 +113,7 @@ losses = compute_ablation_modified_loss(
     model,
     data_loader,
     cached_means=comma_mean_values,
+    vocab_mask=vocab_mask,
     device=device,
     overwrite=OVERWRITE,
 )
@@ -106,30 +133,6 @@ fig.show()
 # %%
 MAX_ORIG_LOSS = 6
 orig_loss_filter = orig_losses > MAX_ORIG_LOSS
-exclude_regex = [
-    r"\]",
-    r"\[",
-    r"\(",
-    r"\)",
-    r",",
-    r":",
-    r";",
-    r"`",
-    r"'",
-    r"\.",
-    r"!",
-    r"\?",
-    r"“",
-    r"{",
-    r"}",
-    r"\\",
-    r"/",
-    r"^g$",
-    r"[0-9]",
-]
-# %%
-exclude_list = construct_exclude_list(model, exclude_regex)
-len(exclude_list)
 # %%
 loss_mask = mask_positions(
     data_loader,

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -287,10 +287,10 @@ class ExperimentData(ABC):
             ]
             data_name = data_files[0].split("/")[-3]
             if name is None:
-                name = data_name
-            assert (
-                name == data_name
-            ), f"Name {name} does not match data name {data_name}"
+                name = data_name.replace("%20", " ")
+            assert name == data_name.replace(
+                "%20", " "
+            ), f"Name {name} does not match data name {data_name.replace('%20', ' ')}"
         if verbose:
             print(
                 f"load_dataset: path={path}, name={name}, split={split}, num_proc={num_proc}, data_files={data_files}"

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -133,6 +133,9 @@ def construct_exclude_list(
     model: HookedTransformer,
     regex: List[str] = DEFAULT_EXCLUDE_REGEX,
 ) -> List[int]:
+    """
+    Constructs a list of token ids based on a regex pattern.
+    """
     assert model.tokenizer is not None
     exclude_list = []
     for vocab_str, token_id in model.tokenizer.vocab.items():

--- a/utils/store.py
+++ b/utils/store.py
@@ -113,6 +113,12 @@ def args_to_file_name(**kwargs):
             continue
         elif hasattr(value, "nelement") and value.nelement() == 0:
             continue
+        elif hasattr(value, "nelement") and value.nelement() == 1:
+            value = value.item()
+            if isinstance(value, int):
+                value = str(value)
+            else:
+                value = "{:.2f}".format(value).replace(".", "_")
         elif hasattr(value, "__len__") and len(value) == 0:
             continue
         elif key in ARGS_TO_INGORE:

--- a/utils/store.py
+++ b/utils/store.py
@@ -109,7 +109,11 @@ def args_to_file_name(**kwargs):
     """Converts a dictionary of arguments to a file name"""
     file_name = ""
     for key, value in kwargs.items():
-        if value is None or (hasattr(value, "__len__") and len(value) == 0):
+        if value is None:
+            continue
+        elif hasattr(value, "nelement") and value.nelement() == 0:
+            continue
+        elif hasattr(value, "__len__") and len(value) == 0:
             continue
         elif key in ARGS_TO_INGORE:
             continue

--- a/utils/tokenwise_ablation.py
+++ b/utils/tokenwise_ablation.py
@@ -280,7 +280,7 @@ def compute_ablation_modified_loss(
         direction_vectors=direction_vectors,
         multiplier=multiplier,
         all_positions=all_positions,
-        vocab_mask=vocab_mask,
+        vocab_mask=(None if vocab_mask is None else vocab_mask.sum()),
         extension="pt",
     )
     if not overwrite and file.exists():

--- a/utils/tokenwise_ablation.py
+++ b/utils/tokenwise_ablation.py
@@ -190,7 +190,7 @@ def subset_cross_entropy_loss(
     logits: Float[torch.Tensor, "batch pos d_vocab"],
     tokens: Int[torch.Tensor, "batch pos"],
     vocab_mask: Optional[Bool[torch.Tensor, "d_vocab"]] = None,
-    inf: float = 1e9,
+    inf: float = float("inf"),
 ) -> Float[torch.Tensor, "batch pos"]:
     """Wrapper around `utils.lm_cross_entropy_loss`.
 
@@ -203,6 +203,11 @@ def subset_cross_entropy_loss(
     if vocab_mask is not None:
         logits = logits.masked_fill(~vocab_mask, -inf)
     loss = lm_cross_entropy_loss(logits, tokens, per_token=True)
+    loss = torch.where(
+        torch.isclose(loss, torch.tensor(inf)),
+        torch.zeros_like(loss),
+        loss,
+    )
     return loss
 
 


### PR DESCRIPTION
# Description

Created a new function `loss_fn` in `utils/tokenwise_ablation.py` which takes a mask to subset the vocabulary. The use case in mind is that you can exclude punctuation from the log prob calculation. 

Also created an AblationHook context to make it easier to run test_prompt with an ablation hook.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
- [x] I have followed the style guide below

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

# Style guide
- My code follows the [Black](https://pypi.org/project/black/) format
- I have minimised type warnings from [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
- Cull any redundant and unused code
- Cache results of slow operations in as flexible of a format as possible, in a flat structure inside results/cache and the file name contains all necessary identifying information (such as model name and dataset used) to avoid accidental overwriting.
- Use intuitive abstractions, making clear the public entrypoints to a given class
- Function and variable names should be long enough to be descriptive


