### PR TITLE
Patching across positions

### DIFF
--- a/github_dataset.py
+++ b/github_dataset.py
@@ -1,0 +1,228 @@
+# %%
+import itertools
+import random
+import einops
+from functools import partial
+import numpy as np
+import torch
+import datasets
+import os
+import re
+from torch import Tensor
+from torch.utils.data import DataLoader
+from datasets import load_dataset, concatenate_datasets
+from jaxtyping import Float, Int, Bool
+from typing import Dict, Iterable, List, Tuple, Union, Literal, Optional
+from transformer_lens import HookedTransformer
+from transformer_lens.utils import (
+    get_dataset,
+    tokenize_and_concatenate,
+    get_act_name,
+    test_prompt,
+    get_attention_mask,
+)
+from transformer_lens.hook_points import HookPoint
+from tqdm.notebook import tqdm
+import pandas as pd
+from circuitsvis.activations import text_neuron_activations
+from circuitsvis.topk_samples import topk_samples
+from IPython.display import HTML, display
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from summarization_utils.patching_metrics import get_logit_diff
+from summarization_utils.tokenwise_ablation import (
+    compute_ablation_modified_loss,
+    load_directions,
+    get_random_directions,
+    get_zeroed_dir_vector,
+    get_layerwise_token_mean_activations,
+    ablation_hook_base,
+    AblationHook,
+    AblationHookIterator,
+    get_batch_token_mean_activations,
+    loss_fn,
+    DEFAULT_DEVICE,
+)
+from summarization_utils.datasets import (
+    OWTData,
+    PileFullData,
+    PileSplittedData,
+    HFData,
+    mask_positions,
+    construct_exclude_list,
+)
+from summarization_utils.neuroscope import plot_top_onesided
+from summarization_utils.store import ResultsFile, TensorBlockManager
+from summarization_utils.path_patching import act_patch, Node, IterNode, IterSeqPos
+from summarization_utils.toy_datasets import (
+    CounterfactualDataset,
+    ToyDeductionTemplate,
+    ToyBindingTemplate,
+    ToyProfilesTemplate,
+)
+from summarization_utils.counterfactual_patching import (
+    patch_by_position_group,
+    patch_by_layer,
+    plot_layer_results_per_batch,
+)
+
+# %%
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+os.environ["TORCH_USE_CUDA_DSA"] = "1"
+torch.set_grad_enabled(False)
+torch.manual_seed(0)
+random.seed(0)
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+# %%
+model: HookedTransformer = HookedTransformer.from_pretrained(
+    "santacoder",
+    torch_dtype=torch.float32,
+    fold_ln=False,
+    center_writing_weights=False,
+    center_unembed=False,
+    device=device,
+)
+assert model.tokenizer is not None
+# %%
+DATASET = [
+    (
+        "for i in range(0, len(data_list)):\n   ",
+        " data",
+        "for j in range(len(im2.imvec)):\n   ",
+        " im",
+    ),
+    (
+        "for i, frame in enumerate(iter_frames(im)):\n    if",
+        " i",
+        "for i in range(0, len(jsonButtonData)):\n    if",
+        " json",
+    ),
+    (
+        "for i in range(len(fig.layout.annotations)):\n   ",
+        " fig",
+        "for target_idx in range(1, len(arr)):\n   ",
+        " target",
+    ),
+    (
+        "for i in range(len(model_infos)):\n   ",
+        " model",
+        "for i in range(0, len(requested)):\n   ",
+        " requested",
+    ),
+    (
+        "for i in range(1,len(y)):\n   ",
+        " y",
+        "for i in range(len(short_answers)):\n   ",
+        " short",
+    ),
+    (
+        "for i in range(len(split_code)):\n   ",
+        " split",
+        "for i in range(len(text_to)):\n   ",
+        " text",
+    ),
+    (
+        "for i in range(len(features)):\n   tr[",
+        "features",
+        "for i in range(len(vocab)):\n    word =",
+        " vocab",
+    ),
+    (
+        "for i in range(len(records)):\n    qid = int(",
+        " records",
+        "for i in range(len(U)):\n    color_map[",
+        "U",
+    ),
+    (
+        "for i in range(1, rgsize + 1):\n   ",
+        " rg",
+        "for idx, xml_file_name in enumerate(files):\n   ",
+        " xml",
+    ),
+    (
+        "for n, d in G.nodes(data=True):\n   ",
+        " G",
+        "for r in pool.imap_unordered(fetch, requested):\n   ",
+        " r",
+    ),
+    (
+        "for factor in range(x, 0, -1):\n    if",
+        " x",
+        "for module, items in iteritems(all_by_module):\n    for",
+        " item",
+    ),
+    (
+        "for button in (left, right, forward, backward):\n   ",
+        " button",
+        "for iidx, video_name in enumerate(videos):\n   ",
+        " video",
+    ),
+    (
+        "for i in xrange(-10, 10):\n    if",
+        " i",
+        "for x in range(1, 101):\n    if",
+        " x",
+    ),
+    (
+        "for test in sorted(all_doctests):    if",
+        " test",
+        "for i in xrange(30000):\n    if",
+        " i",
+    ),
+    (
+        "for cell in dolfin.cells(mesh):\n    contains =",
+        " cell",
+        "for i in range(0, width * height):\n    if(",
+        "i",
+    ),
+    (
+        "for i in range(0,numRuns):\n    #",
+        "i",
+        "for x in range(0,15):\n    print",
+        " x",
+    ),
+    (
+        "for t in (list, dict, set):\n    d[",
+        "t",
+        "for value in range(1,11):\n    square =",
+        " value",
+    ),
+    (
+        "for i in range(1001):\n    x =",
+        " i",
+        "for match in regexp.finditer(data):\n    repr =",
+        " match",
+    ),
+]
+DATASET_NAME = "github"
+# %%
+dataset = CounterfactualDataset.from_tuples(DATASET, model=model)
+print(len(dataset))
+# %%
+dataset.check_lengths_match()
+# %%
+dataset.test_prompts(max_prompts=4, top_k=10)
+# %%
+all_logit_diffs, cf_logit_diffs = dataset.compute_logit_diffs()
+# %%
+print(f"Original mean: {all_logit_diffs.mean():.2f}")
+print(f"Counterfactual mean: {cf_logit_diffs.mean():.2f}")
+# %%
+assert (all_logit_diffs > 0).all()
+assert (cf_logit_diffs < 0).all()
+# %%
+# results_pd = patch_by_position_group(dataset, sep=",")
+# fig = px.bar(
+#     results_pd.mean(axis=0),
+#     labels={"index": "Position", "value": "Patching metric"},
+#     title=f"Patching metric by position group, {model.cfg.model_name}, '{DATASET_NAME}' dataset",
+# )
+# fig.update_layout(showlegend=False)
+# fig.show()
+# %%
+pos_layer_results = patch_by_layer(dataset[:5])
+# %%
+plot_layer_results_per_batch(dataset, pos_layer_results)
+# %%

--- a/github_dataset_mistral.py
+++ b/github_dataset_mistral.py
@@ -65,6 +65,8 @@ from summarization_utils.counterfactual_patching import (
     patch_by_position_group,
     patch_by_layer,
     plot_layer_results_per_batch,
+    patch_by_position,
+    plot_position_results_per_batch,
 )
 
 # %%
@@ -217,16 +219,11 @@ print(f"Counterfactual mean: {cf_logit_diffs.mean():.2f}")
 assert (all_logit_diffs > 0).all()
 assert (cf_logit_diffs < 0).all()
 # %%
-# results_pd = patch_by_position_group(dataset, sep=",")
-# fig = px.bar(
-#     results_pd.mean(axis=0),
-#     labels={"index": "Position", "value": "Patching metric"},
-#     title=f"Patching metric by position group, {model.cfg.model_name}, '{DATASET_NAME}' dataset",
-# )
-# fig.update_layout(showlegend=False)
-# fig.show()
+pos_results = patch_by_position(dataset)
 # %%
-pos_layer_results = patch_by_layer(dataset)
+plot_position_results_per_batch(dataset, pos_results)
 # %%
-plot_layer_results_per_batch(dataset, pos_layer_results)
+# pos_layer_results = patch_by_layer(dataset)
+# # %%
+# plot_layer_results_per_batch(dataset, pos_layer_results)
 # %%

--- a/github_dataset_mistral.py
+++ b/github_dataset_mistral.py
@@ -1,0 +1,232 @@
+# %%
+import itertools
+import random
+import einops
+from functools import partial
+import numpy as np
+import torch
+import datasets
+import os
+import re
+from torch import Tensor
+from torch.utils.data import DataLoader
+from datasets import load_dataset, concatenate_datasets
+from jaxtyping import Float, Int, Bool
+from typing import Dict, Iterable, List, Tuple, Union, Literal, Optional
+from transformer_lens import HookedTransformer
+from transformer_lens.utils import (
+    get_dataset,
+    tokenize_and_concatenate,
+    get_act_name,
+    test_prompt,
+    get_attention_mask,
+)
+from transformer_lens.hook_points import HookPoint
+from tqdm.notebook import tqdm
+import pandas as pd
+from circuitsvis.activations import text_neuron_activations
+from circuitsvis.topk_samples import topk_samples
+from IPython.display import HTML, display
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from summarization_utils.patching_metrics import get_logit_diff
+from summarization_utils.tokenwise_ablation import (
+    compute_ablation_modified_loss,
+    load_directions,
+    get_random_directions,
+    get_zeroed_dir_vector,
+    get_layerwise_token_mean_activations,
+    ablation_hook_base,
+    AblationHook,
+    AblationHookIterator,
+    get_batch_token_mean_activations,
+    loss_fn,
+    DEFAULT_DEVICE,
+)
+from summarization_utils.datasets import (
+    OWTData,
+    PileFullData,
+    PileSplittedData,
+    HFData,
+    mask_positions,
+    construct_exclude_list,
+)
+from summarization_utils.neuroscope import plot_top_onesided
+from summarization_utils.store import ResultsFile, TensorBlockManager
+from summarization_utils.path_patching import act_patch, Node, IterNode, IterSeqPos
+from summarization_utils.toy_datasets import (
+    CounterfactualDataset,
+    ToyDeductionTemplate,
+    ToyBindingTemplate,
+    ToyProfilesTemplate,
+)
+from summarization_utils.counterfactual_patching import (
+    patch_by_position_group,
+    patch_by_layer,
+    plot_layer_results_per_batch,
+)
+
+# %%
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+os.environ["TORCH_USE_CUDA_DSA"] = "1"
+torch.set_grad_enabled(False)
+torch.manual_seed(0)
+random.seed(0)
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+# %%
+model: HookedTransformer = HookedTransformer.from_pretrained(
+    "mistral-7b",
+    torch_dtype=torch.bfloat16,
+    fold_ln=False,
+    center_writing_weights=False,
+    center_unembed=False,
+    device=device,
+)
+assert model.tokenizer is not None
+# %%
+DATASET = [
+    (
+        "for i in range(0, len(data_list)):\n   ",
+        " data",
+        "for j in range(len(im2.imvec)):\n   ",
+        " im",
+    ),
+    # (
+    #     "for i, frame in enumerate(iter_frames(im)):\n    if",
+    #     " i",
+    #     "for i in range(0, len(jsonButtonData)):\n    if",
+    #     " json",
+    # ),
+    (
+        "for i in range(len(fig.layout.annotations)):\n   ",
+        " fig",
+        "for target_idx in range(1, len(arr)):\n   ",
+        " target",
+    ),
+    (
+        "for i in range(len(model_infos)):\n   ",
+        " model",
+        "for i in range(0, len(requested)):\n   ",
+        " requested",
+    ),
+    # (
+    #     "for i in range(1,len(y)):\n   ",
+    #     " y",
+    #     "for i in range(len(short_answers)):\n   ",
+    #     " short",
+    # ),
+    (
+        "for i in range(len(split_code)):\n   ",
+        " split",
+        "for i in range(len(text_to)):\n   ",
+        " text",
+    ),
+    # (
+    #     "for i in range(len(features)):\n   tr[",
+    #     "features",
+    #     "for i in range(len(vocab)):\n    word =",
+    #     " vocab",
+    # ),
+    # (
+    #     "for i in range(len(records)):\n    qid = int(",
+    #     " records",
+    #     "for i in range(len(U)):\n    color_map[",
+    #     "U",
+    # ),
+    (
+        "for i in range(1, rgsize + 1):\n   ",
+        " r",  # " rg",
+        "for idx, xml_file_name in enumerate(files):\n   ",
+        " xml",
+    ),
+    # (
+    #     "for n, d in G.nodes(data=True):\n   ",
+    #     " G",
+    #     "for r in pool.imap_unordered(fetch, requested):\n   ",
+    #     " r",
+    # ),
+    # (
+    #     "for factor in range(x, 0, -1):\n    if",
+    #     " x",
+    #     "for module, items in iteritems(all_by_module):\n    for",
+    #     " item",
+    # ),
+    # (
+    #     "for button in (left, right, forward, backward):\n   ",
+    #     " button",
+    #     "for iidx, video_name in enumerate(videos):\n   ",
+    #     " video",
+    # ),
+    # (
+    #     "for i in xrange(-10, 10):\n    if",
+    #     " i",
+    #     "for x in range(1, 101):\n    if",
+    #     " x",
+    # ),
+    # (
+    #     "for test in sorted(all_doctests):    if",
+    #     " test",
+    #     "for i in xrange(30000):\n    if",
+    #     " i",
+    # ),
+    (
+        "for cell in dolfin.cells(mesh):\n    contains =",
+        " cell",
+        "for i in range(0, width * height):\n    if(",
+        "i",
+    ),
+    # (
+    #     "for i in range(0,numRuns):\n    #",
+    #     "i",
+    #     "for x in range(0,15):\n    print",
+    #     " x",
+    # ),
+    (
+        "for t in (list, dict, set):\n    d[",
+        "t",
+        "for value in range(1,11):\n    square =",
+        " value",
+    ),
+    # (
+    #     "for i in range(1001):\n    x =",
+    #     " i",
+    #     "for match in regexp.finditer(data):\n    repr =",
+    #     " match",
+    # ),
+]
+DATASET = [
+    (prompt, ans.strip(), cf_prompt, cf_ans.strip())
+    for prompt, ans, cf_prompt, cf_ans in DATASET
+]
+DATASET_NAME = "github"
+# %%
+dataset = CounterfactualDataset.from_tuples(DATASET, model=model)
+print(len(dataset))
+# %%
+dataset.check_lengths_match()
+# %%
+dataset.test_prompts(max_prompts=4, top_k=10)
+# %%
+all_logit_diffs, cf_logit_diffs = dataset.compute_logit_diffs()
+# %%
+print(f"Original mean: {all_logit_diffs.mean():.2f}")
+print(f"Counterfactual mean: {cf_logit_diffs.mean():.2f}")
+# %%
+assert (all_logit_diffs > 0).all()
+assert (cf_logit_diffs < 0).all()
+# %%
+# results_pd = patch_by_position_group(dataset, sep=",")
+# fig = px.bar(
+#     results_pd.mean(axis=0),
+#     labels={"index": "Position", "value": "Patching metric"},
+#     title=f"Patching metric by position group, {model.cfg.model_name}, '{DATASET_NAME}' dataset",
+# )
+# fig.update_layout(showlegend=False)
+# fig.show()
+# %%
+pos_layer_results = patch_by_layer(dataset)
+# %%
+plot_layer_results_per_batch(dataset, pos_layer_results)
+# %%

--- a/github_dataset_triple_colon.py
+++ b/github_dataset_triple_colon.py
@@ -95,14 +95,14 @@ DATASET = [
         "for i in range(len(fig.layout.annotations)):\n   ",
         " fig",
     ),
-    (
-        "for target_idx in range(1, len(arr)):\n   ",
-        " target",
-        "for i in range(len(records)):\n    qid = int(",
-        " records",
-        "for i in range(len(U)):\n    color_map[",
-        "U",
-    ),
+    # (
+    #     "for target_idx in range(1, len(arr)):\n   ",
+    #     " target",
+    #     "for i in range(len(records)):\n    qid = int(",
+    #     " records",
+    #     "for i in range(len(U)):\n    color_map[",
+    #     "U",
+    # ),
     (
         "for i in range(1, rgsize + 1):\n   ",
         " rg",
@@ -111,22 +111,22 @@ DATASET = [
         "for n, d in G.nodes(data=True):\n   ",
         " G",
     ),
-    (
-        "for r in pool.imap_unordered(fetch, requested):\n   ",
-        " r",
-        "for i in xrange(-10, 10):\n    if",
-        " i",
-        "for x in range(1, 101):\n    if",
-        " x",
-    ),
-    (
-        "for i, frame in enumerate(iter_frames(im)):\n    if",
-        " i",
-        "for i in range(0, len(jsonButtonData)):\n    if",
-        " json",
-        "for factor in range(x, 0, -1):\n    if",
-        " x",
-    ),  # 16
+    # (
+    #     "for r in pool.imap_unordered(fetch, requested):\n   ",
+    #     " r",
+    #     "for i in xrange(-10, 10):\n    if",
+    #     " i",
+    #     "for x in range(1, 101):\n    if",
+    #     " x",
+    # ),
+    # (
+    #     "for i, frame in enumerate(iter_frames(im)):\n    if",
+    #     " i",
+    #     "for i in range(0, len(jsonButtonData)):\n    if",
+    #     " json",
+    #     "for factor in range(x, 0, -1):\n    if",
+    #     " x",
+    # ),  # 16
     (
         "for i in range(len(model_infos)):\n   ",
         " model",
@@ -143,36 +143,45 @@ DATASET = [
         "for i in range(len(text_to)):\n   ",
         " text",
     ),
-    (
-        "for i in range(len(features)):\n   tr[",
-        "features",
-        "for i in range(len(vocab)):\n    word =",
-        " vocab",
-        "for i in range(0,numRuns):\n    #",
-        "i",
-    ),
-    (
-        "for button in (left, right, forward, backward):\n   ",
-        " button",
-        "for iidx, video_name in enumerate(videos):\n   ",
-        " video",
-        "for test in sorted(all_doctests):    if",
-        " test",
-    ),
-    (
-        "for i in xrange(30000):\n    if",
-        " i",
-        "for t in (list, dict, set):\n    d[",
-        "t",
-        "for value in range(1,11):\n    square =",
-        " value",
-    ),
+    # (
+    #     "for i in range(len(features)):\n   tr[",
+    #     "features",
+    #     "for i in range(len(vocab)):\n    word =",
+    #     " vocab",
+    #     "for i in range(0,numRuns):\n    #",
+    #     "i",
+    # ),
+    # (
+    #     "for i in range(len(vocab)):\n    word =",
+    #     " vocab",
+    #     "for t in (list, dict, set):\n    d[",
+    #     "t",
+    #     "for value in range(1,11):\n    square =",
+    #     " value",
+    # ),
 ]
 DATASET_NAME = "github"
 # %%
 for p1, a1, p2, a2, p3, a3 in DATASET:
     assert len(model.to_str_tokens(p1)) == len(model.to_str_tokens(p2))
     assert len(model.to_str_tokens(p1)) == len(model.to_str_tokens(p3))
+# %%
+for p1, a1, p2, a2, p3, a3 in DATASET:
+    p1_str_tokens = model.to_str_tokens(p1)
+    p2_str_tokens = model.to_str_tokens(p2)
+    p3_str_tokens = model.to_str_tokens(p3)
+    assert [i for i, s in enumerate(p1_str_tokens) if ":" in s] == [
+        i for i, s in enumerate(p2_str_tokens) if ":" in s
+    ], f"\n{p1_str_tokens}\n{p2_str_tokens}\n{p3_str_tokens}"
+    assert [i for i, s in enumerate(p1_str_tokens) if ":" in s] == [
+        i for i, s in enumerate(p3_str_tokens) if ":" in s
+    ], f"\n{p1_str_tokens}\n{p2_str_tokens}\n{p3_str_tokens}"
+    assert [s for i, s in enumerate(p1_str_tokens) if ":" in s] == [
+        s for i, s in enumerate(p2_str_tokens) if ":" in s
+    ], f"\n{p1_str_tokens}\n{p2_str_tokens}\n{p3_str_tokens}"
+    assert [s for i, s in enumerate(p1_str_tokens) if ":" in s] == [
+        s for i, s in enumerate(p3_str_tokens) if ":" in s
+    ], f"\n{p1_str_tokens}\n{p2_str_tokens}\n{p3_str_tokens}"
 # %%
 for batch, (p1, a1, p2, a2, p3, a3) in enumerate(DATASET):
     test_prompt(p1, a1, model, prepend_space_to_answer=False)
@@ -247,10 +256,11 @@ def triple_metric_base(
 
 # %%
 results_list = []
-for p1, a1, p2, a2, p3, a3 in DATASET[:2]:
+for p1, a1, p2, a2, p3, a3 in DATASET:
     orig_input = model.to_tokens(p1, prepend_bos=True)
     orig_logits = model(orig_input, return_type="logits")
     orig12, orig13 = triple_metric_base(orig_logits, model, a1, a2, a3)
+    print("orig", orig12, orig13)
     prompt_str_tokens = model.to_str_tokens(p1, prepend_bos=True)
     new_logit_diffs = []
     for cf_idx in (0, 1):
@@ -310,7 +320,7 @@ for batch in range(results.shape[0]):
                 name=f"batch={batch}, cf={cf+1}",
                 colorscale="RdBu",
                 zmin=0,
-                zmax=1,
+                zmax=0.5,
                 hovertemplate="answer=%{x}<br>layer=%{y}<br>logit diff=%{z:.1%}",
             ),
             row=batch + 1,

--- a/github_dataset_triple_colon.py
+++ b/github_dataset_triple_colon.py
@@ -1,0 +1,296 @@
+# %%
+import itertools
+import random
+import einops
+from functools import partial
+import numpy as np
+import torch
+import datasets
+import os
+import re
+from torch import Tensor
+from torch.utils.data import DataLoader
+from datasets import load_dataset, concatenate_datasets
+from jaxtyping import Float, Int, Bool
+from typing import Dict, Iterable, List, Tuple, Union, Literal, Optional
+from transformer_lens import HookedTransformer
+from transformer_lens.utils import (
+    get_dataset,
+    tokenize_and_concatenate,
+    get_act_name,
+    test_prompt,
+    get_attention_mask,
+)
+from transformer_lens.hook_points import HookPoint
+from tqdm.notebook import tqdm
+import pandas as pd
+from circuitsvis.activations import text_neuron_activations
+from circuitsvis.topk_samples import topk_samples
+from IPython.display import HTML, display
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from summarization_utils.patching_metrics import get_logit_diff
+from summarization_utils.tokenwise_ablation import (
+    compute_ablation_modified_loss,
+    load_directions,
+    get_random_directions,
+    get_zeroed_dir_vector,
+    get_layerwise_token_mean_activations,
+    ablation_hook_base,
+    AblationHook,
+    AblationHookIterator,
+    get_batch_token_mean_activations,
+    loss_fn,
+    DEFAULT_DEVICE,
+)
+from summarization_utils.datasets import (
+    OWTData,
+    PileFullData,
+    PileSplittedData,
+    HFData,
+    mask_positions,
+    construct_exclude_list,
+)
+from summarization_utils.neuroscope import plot_top_onesided
+from summarization_utils.store import ResultsFile, TensorBlockManager
+from summarization_utils.path_patching import act_patch, Node, IterNode, IterSeqPos
+from summarization_utils.toy_datasets import (
+    CounterfactualDataset,
+    ToyDeductionTemplate,
+    ToyBindingTemplate,
+    ToyProfilesTemplate,
+)
+from summarization_utils.counterfactual_patching import (
+    patch_by_position_group,
+    patch_by_layer,
+    plot_layer_results_per_batch,
+)
+
+# %%
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+os.environ["TORCH_USE_CUDA_DSA"] = "1"
+torch.set_grad_enabled(False)
+torch.manual_seed(0)
+random.seed(0)
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+# %%
+model: HookedTransformer = HookedTransformer.from_pretrained(
+    "santacoder",
+    torch_dtype=torch.float32,
+    fold_ln=False,
+    center_writing_weights=False,
+    center_unembed=False,
+    device=device,
+)
+assert model.tokenizer is not None
+# %%
+DATASET = [
+    (
+        "for i in range(0, len(data_list)):\n   ",
+        " data",
+        "for j in range(len(im2.imvec)):\n   ",
+        " im",
+        "for i in range(len(fig.layout.annotations)):\n   ",
+        " fig",
+    ),
+    (
+        "for target_idx in range(1, len(arr)):\n   ",
+        " target",
+        "for i in range(len(records)):\n    qid = int(",
+        " records",
+        "for i in range(len(U)):\n    color_map[",
+        "U",
+    ),
+    (
+        "for i in range(1, rgsize + 1):\n   ",
+        " rg",
+        "for idx, xml_file_name in enumerate(files):\n   ",
+        " xml",
+        "for n, d in G.nodes(data=True):\n   ",
+        " G",
+    ),
+    (
+        "for r in pool.imap_unordered(fetch, requested):\n   ",
+        " r",
+        "for i in xrange(-10, 10):\n    if",
+        " i",
+        "for x in range(1, 101):\n    if",
+        " x",
+    ),
+    (
+        "for i, frame in enumerate(iter_frames(im)):\n    if",
+        " i",
+        "for i in range(0, len(jsonButtonData)):\n    if",
+        " json",
+        "for factor in range(x, 0, -1):\n    if",
+        " x",
+    ),  # 16
+    (
+        "for i in range(len(model_infos)):\n   ",
+        " model",
+        "for i in range(0, len(requested)):\n   ",
+        " requested",
+        "for i in range(1,len(y)):\n   ",
+        " y",
+    ),
+    (
+        "for i in range(len(short_answers)):\n   ",
+        " short",
+        "for i in range(len(split_code)):\n   ",
+        " split",
+        "for i in range(len(text_to)):\n   ",
+        " text",
+    ),
+    (
+        "for i in range(len(features)):\n   tr[",
+        "features",
+        "for i in range(len(vocab)):\n    word =",
+        " vocab",
+        "for i in range(0,numRuns):\n    #",
+        "i",
+    ),
+    (
+        "for button in (left, right, forward, backward):\n   ",
+        " button",
+        "for iidx, video_name in enumerate(videos):\n   ",
+        " video",
+        "for test in sorted(all_doctests):    if",
+        " test",
+    ),
+    (
+        "for i in xrange(30000):\n    if",
+        " i",
+        "for t in (list, dict, set):\n    d[",
+        "t",
+        "for value in range(1,11):\n    square =",
+        " value",
+    ),
+]
+DATASET_NAME = "github"
+# %%
+for p1, a1, p2, a2, p3, a3 in DATASET:
+    assert len(model.to_str_tokens(p1)) == len(model.to_str_tokens(p2))
+    assert len(model.to_str_tokens(p1)) == len(model.to_str_tokens(p3))
+# %%
+for batch, (p1, a1, p2, a2, p3, a3) in enumerate(DATASET):
+    test_prompt(p1, a1, model, prepend_space_to_answer=False)
+    test_prompt(p2, a2, model, prepend_space_to_answer=False)
+    test_prompt(p3, a3, model, prepend_space_to_answer=False)
+    if batch > 1:
+        break
+# %%
+logit_diffs = []
+for i, (p1, a1, p2, a2, p3, a3) in enumerate(DATASET):
+    orig_input = model.to_tokens(p1, prepend_bos=True)
+    orig_logits = model(orig_input, return_type="logits")
+    for cf in (0, 1):
+        cf_logits = model(p2 if cf == 0 else p3, return_type="logits", prepend_bos=True)
+        answer_tokens = torch.tensor(
+            [
+                model.to_single_token(a1),
+                model.to_single_token(a2 if cf == 0 else a3),
+            ],
+            device=device,
+        ).unsqueeze(0)
+        cf_answer_tokens = torch.tensor(
+            [
+                model.to_single_token(a2 if cf == 0 else a3),
+                model.to_single_token(a1),
+            ],
+            device=device,
+        ).unsqueeze(0)
+        orig_logit_diff = get_logit_diff(orig_logits, answer_tokens=answer_tokens)
+        cf_logit_diff = get_logit_diff(cf_logits, answer_tokens=cf_answer_tokens)
+        logit_diffs.append(orig_logit_diff)
+        logit_diffs.append(cf_logit_diff)
+        # print(orig_logits[-1, -1, model.to_single_token(a1)])
+        # print(cf_logits[-1, -1, model.to_single_token(a1)])
+        # print(orig_logits[-1, -1, model.to_single_token(a2 if cf == 0 else a3)])
+        # print(cf_logits[-1, -1, model.to_single_token(a2 if cf == 0 else a3)])
+logit_diffs = torch.stack(logit_diffs, dim=0)
+print(logit_diffs.mean().item(), (logit_diffs > 0).float().mean().item())
+
+
+# %%
+def triple_metric_base(
+    logits: Float[Tensor, "batch seq vocab"],
+    model: HookedTransformer,
+    a1: str,
+    a2: str,
+    a3: str,
+    baseline: Optional[Float[Tensor, "3"]] = None,
+) -> Float[Tensor, "3"]:
+    if baseline is None:
+        baseline = torch.zeros(3, dtype=torch.float32)
+    log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
+    return (
+        torch.tensor(
+            [
+                log_probs[-1, -1, model.to_single_token(a1)].item(),
+                log_probs[-1, -1, model.to_single_token(a2)].item(),
+                log_probs[-1, -1, model.to_single_token(a3)].item(),
+            ]
+        )
+        - baseline
+    )
+
+
+# %%
+results_list = []
+for p1, a1, p2, a2, p3, a3 in DATASET[:5]:
+    orig_input = model.to_tokens(p1, prepend_bos=True)
+    orig_logits = model(orig_input, return_type="logits")
+    orig_triple = triple_metric_base(orig_logits, model, a1, a2, a3)
+    prompt_str_tokens = model.to_str_tokens(p1, prepend_bos=True)
+    metric = partial(
+        triple_metric_base, model=model, a1=a1, a2=a2, a3=a3, baseline=orig_triple
+    )
+    seq_pos = [i for i, s in enumerate(prompt_str_tokens) if ":" in s]
+    assert len(seq_pos) == 1
+    nodes = IterNode(node_names=["resid_pre"], seq_pos=seq_pos)
+    for cf_idx in (0, 1):
+        new_input = [p2, p3][cf_idx]
+        result = act_patch(
+            model, orig_input, nodes, metric, new_input=new_input, verbose=True
+        )[
+            "resid_pre"
+        ]  # type: ignore
+        result: Float[Tensor, "layer"] = torch.stack(result, dim=0)  # type: ignore
+        results_list.append(result)
+print(results_list[0])
+# %%
+results: Float[Tensor, "batch cf layer answer"] = einops.rearrange(
+    torch.stack(results_list, dim=0),
+    "(batch cf) layer answer -> batch cf layer answer",
+    cf=2,
+)
+print(results.shape)
+# %%
+fig = make_subplots(
+    rows=results.shape[0],
+    cols=results.shape[1],
+)
+for batch in range(results.shape[0]):
+    for cf in range(results.shape[1]):
+        fig.add_trace(
+            go.Heatmap(
+                z=results[batch, cf],
+                name=f"batch={batch}, cf={cf+1}",
+                colorscale="RdBu",
+                zmin=-20,
+                zmax=0,
+                hovertemplate="answer=%{x}<br>layer=%{y}<br>logit=%{z:.2f}",
+            ),
+            row=batch + 1,
+            col=cf + 1,
+        )
+        fig.update_xaxes(title_text="answer", row=batch + 1, col=cf + 1)
+        fig.update_yaxes(title_text="layer", row=batch + 1, col=cf + 1)
+fig.update_layout(
+    height=results.shape[0] * 400,
+    width=results.shape[1] * 400,
+)
+
+# %%

--- a/patching_in_the_wild.py
+++ b/patching_in_the_wild.py
@@ -1,0 +1,216 @@
+# %%
+import itertools
+import random
+import einops
+from functools import partial
+import numpy as np
+import torch
+import datasets
+import os
+import re
+from torch import Tensor
+from torch.utils.data import DataLoader
+from datasets import load_dataset, concatenate_datasets
+from jaxtyping import Float, Int, Bool
+from typing import Dict, Iterable, List, Tuple, Union, Literal, Optional, Generator
+from transformer_lens import HookedTransformer
+from transformer_lens.utils import (
+    get_dataset,
+    tokenize_and_concatenate,
+    get_act_name,
+    test_prompt,
+    get_attention_mask,
+)
+from transformer_lens.hook_points import HookPoint
+from tqdm.notebook import tqdm
+import pandas as pd
+from circuitsvis.activations import text_neuron_activations
+from circuitsvis.topk_samples import topk_samples
+from IPython.display import HTML, display
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from summarization_utils.patching_metrics import get_logit_diff
+from summarization_utils.tokenwise_ablation import (
+    compute_ablation_modified_loss,
+    load_directions,
+    get_random_directions,
+    get_zeroed_dir_vector,
+    get_layerwise_token_mean_activations,
+    ablation_hook_base,
+    AblationHook,
+    AblationHookIterator,
+    get_batch_token_mean_activations,
+    loss_fn,
+    DEFAULT_DEVICE,
+)
+from summarization_utils.datasets import (
+    OWTData,
+    PileFullData,
+    PileSplittedData,
+    HFData,
+    mask_positions,
+    construct_exclude_list,
+)
+from summarization_utils.neuroscope import plot_top_onesided
+from summarization_utils.store import ResultsFile, TensorBlockManager
+from summarization_utils.path_patching import act_patch, Node, IterNode, IterSeqPos
+from typing import Generator
+from summarization_utils.toy_datasets import (
+    CounterfactualDataset,
+    ToyDeductionTemplate,
+    ToyBindingTemplate,
+    ToyProfilesTemplate,
+)
+from summarization_utils.counterfactual_patching import (
+    patch_by_position_group,
+    patch_by_layer,
+    plot_layer_results_per_batch,
+)
+
+# %%
+SPLIT = "train"
+DATA_FILES = [
+    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/ArXiv/train/data-00000-of-00222.arrow",
+    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/BookCorpus2/train/data-00000-of-00096.arrow",
+    "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/Github/train/data-00000-of-00191.arrow"
+    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/Gutenberg%20(PG-19)/train/data-00000-of-00096.arrow",
+    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/PhilPapers/train/data-00000-of-00096.arrow",
+    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/PubMed%20Abstracts/train/data-00000-of-00096.arrow",
+    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/Wikipedia%20(en)/train/data-00000-of-00101.arrow",
+]
+NAME = DATA_FILES[0].split("/")[-3].replace("%20", " ")
+BATCH_SIZE = 64
+# %%
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+os.environ["TORCH_USE_CUDA_DSA"] = "1"
+torch.set_grad_enabled(False)
+torch.manual_seed(0)
+random.seed(0)
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+# %%
+model: HookedTransformer = HookedTransformer.from_pretrained(
+    "santacoder",
+    torch_dtype=torch.float32,
+    fold_ln=False,
+    center_writing_weights=False,
+    center_unembed=False,
+    device=device,
+)
+assert model.tokenizer is not None
+# %%
+exp_data = PileSplittedData.from_model(
+    model,
+    name=NAME,
+    split=SPLIT,
+    data_files=DATA_FILES,
+    verbose=True,
+)
+ablation_token: int = model.to_single_token(":")  # type: ignore
+exp_data.preprocess_datasets(token_to_ablate=ablation_token)
+# %%
+data_loader = exp_data.get_dataloaders(batch_size=BATCH_SIZE)[SPLIT]
+# %%
+template = "for i in range(x"  # x: \n    print( TODO: start simple here and then move to more complex
+tokens = model.to_tokens(template, prepend_bos=False)
+str_tokens = model.to_str_tokens(tokens, prepend_bos=False)
+search_tokens = [
+    t if "x" not in s else -1 for t, s in zip(tokens.tolist()[0], str_tokens)
+]
+print(search_tokens)
+
+
+# %%
+def find_subtensor(
+    main_tensor: Int[Tensor, "*batch pos"],
+    sub_tensor: Int[Tensor, "sub_pos"],
+    wildcard_value: int = -1,
+    verbose: bool = False,
+) -> Generator[Tensor, None, None]:
+    """
+    main_tensor: main tensor to search e.g. torch.tensor([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    sub_tensor: sub-tensor to search for in main_tensor, e.g. torch.tensor([3, 0, 5])
+    wildcard_tensor: treat this value as a wildcard, e.g. 0
+    out: list of found sub-tensors, e.g. [torch.tensor([3, 4, 5])]
+    """
+    if main_tensor.ndim == 1:
+        main_tensor = main_tensor.unsqueeze(0)
+    is_wildcard = sub_tensor == wildcard_value
+    for batch_idx, batch in enumerate(main_tensor):
+        for i in range(len(batch) - len(sub_tensor) + 1):
+            is_match = batch[i : i + len(sub_tensor)] == sub_tensor
+            if torch.all(is_match | is_wildcard):
+                if verbose:
+                    print(
+                        f"Found match at batch {batch_idx}, pos {i}: {batch[i:i+len(sub_tensor)]}"
+                    )
+                yield batch[i : i + len(sub_tensor)]
+
+
+# def find_subtensor(
+#     main_tensor: torch.Tensor,
+#     sub_tensor: torch.Tensor,
+#     wildcard_value: int = -1,
+#     verbose: bool = False,
+# ) -> torch.Tensor:
+
+#     # Move tensors to GPU
+#     main_tensor = main_tensor.to('cuda')
+#     sub_tensor = sub_tensor.to('cuda')
+
+#     if main_tensor.ndim == 1:
+#         main_tensor = main_tensor.unsqueeze(0)
+
+#     is_wildcard = sub_tensor == wildcard_value
+#     is_wildcard = is_wildcard.unsqueeze(1)
+
+#     # Use unfold to generate all sub-tensors
+#     sub_tensors = main_tensor.unfold(1, sub_tensor.size(0), 1)
+#     is_match = sub_tensors == sub_tensor
+#     indices = torch.all(is_match | is_wildcard, dim=2)
+#     result = torch.masked_select(sub_tensors, indices.unsqueeze(2)).view(-1, sub_tensor.size(0))
+
+#     if verbose:
+#         print(f"Found match : {result}")
+#     return result
+
+
+# # %%
+# out = find_subtensor(
+#     torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 3, 2, 5, 6, 7, 8, 9, 0]]),
+#     torch.tensor([3, -1, 5]),
+#     -1,
+# )
+# list(out)
+# # %%
+# out = find_subtensor(
+#     torch.tensor([[1, 2, 3, 4, 5, 6, 3, 8, 5], [1, 3, 2, 5, 6, 7, 8, 9, 0]]),
+#     torch.tensor([3, -1, 5]),
+#     -1,
+# )
+# list(out)
+# # %%
+# search_function = partial(
+#     find_subtensor,
+#     sub_tensor=torch.tensor(search_tokens, device=device),
+#     wildcard_value=-1,
+#     verbose=True,
+# )
+# # %%
+# out = search_function(model.to_tokens("for x in x: \n    print("))
+# list(out)
+# %%
+MAX_RESULTS = 100
+results = []
+for batch in tqdm(data_loader, total=len(data_loader)):
+    for result in find_subtensor(
+        batch["tokens"], torch.tensor(search_tokens), -1, verbose=True
+    ):
+        results.append(result)
+    if len(results) >= MAX_RESULTS:
+        break
+# %%
+for result in results:
+    print(model.to_str_tokens(result))
+# %%

--- a/patching_in_the_wild.py
+++ b/patching_in_the_wild.py
@@ -71,16 +71,11 @@ from summarization_utils.counterfactual_patching import (
 # %%
 SPLIT = "train"
 DATA_FILES = [
-    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/ArXiv/train/data-00000-of-00222.arrow",
-    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/BookCorpus2/train/data-00000-of-00096.arrow",
-    "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/Github/train/data-00000-of-00191.arrow"
-    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/Gutenberg%20(PG-19)/train/data-00000-of-00096.arrow",
-    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/PhilPapers/train/data-00000-of-00096.arrow",
-    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/PubMed%20Abstracts/train/data-00000-of-00096.arrow",
-    # "https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/Wikipedia%20(en)/train/data-00000-of-00101.arrow",
+    f"https://huggingface.co/datasets/ArmelR/the-pile-splitted/blob/main/data/Github/train/data-{i:05d}-of-00191.arrow"
+    for i in range(10)
 ]
 NAME = DATA_FILES[0].split("/")[-3].replace("%20", " ")
-BATCH_SIZE = 64
+BATCH_SIZE = 1024
 # %%
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
@@ -112,13 +107,33 @@ exp_data.preprocess_datasets(token_to_ablate=ablation_token)
 # %%
 data_loader = exp_data.get_dataloaders(batch_size=BATCH_SIZE)[SPLIT]
 # %%
-template = "for i in range(x"  # x: \n    print( TODO: start simple here and then move to more complex
+template = "for i in range(1, len(sys.argv)):\n   "
 tokens = model.to_tokens(template, prepend_bos=False)
 str_tokens = model.to_str_tokens(tokens, prepend_bos=False)
+print([f"{s}:{t}" for s, t in zip(str_tokens, tokens[0].tolist())])
 search_tokens = [
-    t if "x" not in s else -1 for t, s in zip(tokens.tolist()[0], str_tokens)
+    996,  # for
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    3554,  # )):
+    258,  # 258 is 3, 246 is 4 spaces
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
+    -1,
 ]
-print(search_tokens)
 # %%
 
 
@@ -127,6 +142,7 @@ def find_subtensor(
     sub_tensor: torch.Tensor,
     wildcard_value: int = -1,
     device: torch.device = torch.device("cuda"),
+    return_full_batch: bool = False,
 ) -> torch.Tensor:
     # Move tensors to GPU
     main_tensor = main_tensor.to(device)
@@ -141,6 +157,8 @@ def find_subtensor(
     sub_tensors = main_tensor.unfold(1, sub_tensor.size(0), 1)
     is_match = sub_tensors == sub_tensor
     indices = torch.all(is_match | is_wildcard, dim=2)
+    if return_full_batch:
+        return torch.where(indices)[0]
     result = torch.masked_select(sub_tensors, indices.unsqueeze(2)).view(
         -1, sub_tensor.size(0)
     )
@@ -152,16 +170,22 @@ search_function = partial(
     find_subtensor,
     sub_tensor=torch.tensor(search_tokens, device=device),
     wildcard_value=-1,
+    return_full_batch=True,
 )
 # %%
 MAX_RESULTS = 100
 results = []
-for batch in tqdm(data_loader, total=len(data_loader)):
+for batch_num, batch in enumerate(tqdm(data_loader, total=len(data_loader))):
     for result in search_function(batch["tokens"]):
-        results.append(result)
+        results.append(batch_num * BATCH_SIZE + result)
     if len(results) >= MAX_RESULTS:
         break
 # %%
-for result in results:
-    print(model.to_str_tokens(result))
+print(len(results))
 # %%
+for result in results:
+    tokens = exp_data.dataset_dict[SPLIT][result.item()]["tokens"]
+    print(model.to_string(tokens))
+
+# %%
+# TODO: try to get O(100) results and then find a way to pair them up and truncate them nicely

--- a/summarization_utils/datasets.py
+++ b/summarization_utils/datasets.py
@@ -108,7 +108,7 @@ def tokenize_truncate_concatenate(
         tokens: Int[np.ndarray, "batch seq"] = tokenizer(
             text,
             return_tensors="np",
-            padding=padding,
+            padding="max_length" if padding else None,
             truncation=truncation,
             max_length=seq_len,
         )[  # type: ignore

--- a/summarization_utils/toy_datasets.py
+++ b/summarization_utils/toy_datasets.py
@@ -1016,6 +1016,25 @@ class CounterfactualDataset:
     def __len__(self):
         return len(self.prompts)
 
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            # If the index is a slice, return a new CounterfactualDataset with the sliced data
+            return CounterfactualDataset(
+                prompts=self.prompts[idx],
+                answers=self.answers[idx],
+                cf_prompts=self.cf_prompts[idx],
+                cf_answers=self.cf_answers[idx],
+                model=self.model,
+            )
+        else:
+            # If the index is an integer, return a tuple with the data at that index
+            return (
+                self.prompts[idx],
+                self.answers[idx],
+                self.cf_prompts[idx],
+                self.cf_answers[idx],
+            )
+
     def shuffle(self, seed: int = 0) -> "CounterfactualDataset":
         random.seed(seed)
         index = list(range(len(self)))

--- a/toy_world_model.py
+++ b/toy_world_model.py
@@ -59,6 +59,7 @@ from summarization_utils.datasets import (
 from summarization_utils.neuroscope import plot_top_onesided
 from summarization_utils.store import ResultsFile, TensorBlockManager
 from summarization_utils.path_patching import act_patch, Node, IterNode, IterSeqPos
+from typing import Sequence
 from summarization_utils.toy_datasets import (
     CounterfactualDataset,
     ToyDeductionTemplate,
@@ -139,53 +140,79 @@ model = HookedMistral.from_pretrained(
 )
 assert model.tokenizer is not None
 # %%
-# test_prompt(
-#     "[INST] Anne carried her cane, hat and glasses. Anne lost her cane on the walk. Anne found her cane again in some bushes. Question: Does Anne have her cane? Answer (Yes/No): [/INST]",
-#     " Yes",
-#     model,
-#     prepend_space_to_answer=False,
-# )
-# %%
-PROMPT_ANSWER_PAIRS = [
+DATA_TUPLES: List[Tuple[str, str, str, str]] = [
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " No",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    # ),
     (
         "[INST] Anne carried her stick, hat and glasses. Anne lost her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
         " No",
-    ),
-    (
-        "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
-        " Yes",
-    ),
-    (
         "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
         " Yes",
     ),
-    (
-        "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
-        " Yes",
-    ),
-    (
-        "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
-        " Yes",
-    ),
-    (
-        "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her hat? Answer (Yes/No): [/INST]",
-        " No",
-    ),
-    (
-        "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her glasses? Answer (Yes/No): [/INST]",
-        " No",
-    ),
-]
-# %%
-# for prompt, answer in PROMPT_ANSWER_PAIRS:
-#     test_prompt(prompt, answer, model, prepend_space_to_answer=False)
-# %%
-DATA_TUPLES = [
-    (prompt, answer, cf_prompt, cf_answer)
-    for (prompt, answer), (cf_prompt, cf_answer) in itertools.combinations(
-        PROMPT_ANSWER_PAIRS, 2
-    )
-    if answer != cf_answer
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " No",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " No",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her hat? Answer (Yes/No): [/INST]",
+    #     " No",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her glasses? Answer (Yes/No): [/INST]",
+    #     " No",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her hat? Answer (Yes/No): [/INST]",
+    #     " No",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her glasses? Answer (Yes/No): [/INST]",
+    #     " No",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her hat? Answer (Yes/No): [/INST]",
+    #     " No",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her glasses? Answer (Yes/No): [/INST]",
+    #     " No",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her hat? Answer (Yes/No): [/INST]",
+    #     " No",
+    # ),
+    # (
+    #     "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+    #     " Yes",
+    #     "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her glasses? Answer (Yes/No): [/INST]",
+    #     " No",
+    # ),
 ]
 # %%
 dataset = CounterfactualDataset.from_tuples(DATA_TUPLES, model)
@@ -208,3 +235,77 @@ pos_layer_results = patch_by_layer(dataset)
 # %%
 plot_layer_results_per_batch(dataset, pos_layer_results)
 # %%
+# #############################################################################
+# Patching across positions
+# #############################################################################
+# %%
+prompt = dataset.prompts[0]
+answer = dataset.answers[0]
+cf_prompt = dataset.cf_prompts[0]
+cf_answer = dataset.cf_answers[0]
+prepend_bos: bool = True
+# %%
+[f"{i}: {t}" for i, t in enumerate(model.to_str_tokens(prompt))]
+# %%
+prompt_tokens = model.to_tokens(prompt, prepend_bos=prepend_bos)
+cf_tokens = model.to_tokens(cf_prompt, prepend_bos=prepend_bos)
+answer_id = model.to_single_token(answer)
+cf_answer_id = model.to_single_token(cf_answer)
+answer_tokens = torch.tensor(
+    [answer_id, cf_answer_id], dtype=torch.int64, device=model.cfg.device
+).unsqueeze(0)
+assert prompt_tokens.shape == cf_tokens.shape, (
+    f"Prompt and counterfactual prompt must have the same shape, "
+    f"for prompt {prompt} "
+    f"got {prompt_tokens.shape} and {cf_tokens.shape}"
+)
+model.reset_hooks(including_permanent=True)
+base_logits_by_pos, base_cache = model.run_with_cache(
+    prompt_tokens,
+    prepend_bos=False,
+    return_type="logits",
+)
+base_logits: Float[Tensor, "... d_vocab"] = base_logits_by_pos[:, -1, :]
+base_ldiff = get_logit_diff(base_logits, answer_tokens=answer_tokens)
+cf_logits, cf_cache = model.run_with_cache(
+    cf_tokens, prepend_bos=False, return_type="logits"
+)
+assert isinstance(cf_logits, Tensor)
+cf_ldiff = get_logit_diff(cf_logits, answer_tokens=answer_tokens)
+metric = lambda logits: (
+    get_logit_diff(logits, answer_tokens=answer_tokens) - base_ldiff
+) / (cf_ldiff - base_ldiff)
+# %%
+stick_positions = [7, 16, 27]
+# %%
+resids = []
+labels = []
+for cache_str in ("base", "cf"):
+    cache = base_cache if cache_str == "base" else cf_cache
+    for pos_idx, pos in enumerate(stick_positions):
+        for layer in range(model.cfg.n_layers):
+            resids.append(cache["resid_pre", layer][:, pos, :])
+            labels.append(f"{cache_str} L{layer} P{pos_idx+1}")
+resids = torch.cat(resids, dim=0)
+cosine_sims = (resids @ resids.T) / (
+    resids.norm(dim=-1, keepdim=True) @ resids.norm(dim=-1, keepdim=True).T
+)
+cosine_sims = cosine_sims.cpu().to(dtype=torch.float32).numpy()
+print(resids.shape, cosine_sims.shape)
+# %%
+# plot cosine similarity matrix between the residuals
+fig = px.imshow(
+    cosine_sims,
+    x=labels,
+    y=labels,
+    width=1200,
+    height=1200,
+    title="Cosine Similarity Matrix",
+)
+fig.update_layout(
+    title_x=0.5,
+)
+fig.show()
+# %%
+# What is up with the weird discontinuity at L20?
+# cf middle position is very different to other positions as expected

--- a/toy_world_model.py
+++ b/toy_world_model.py
@@ -1,0 +1,210 @@
+# %%
+import itertools
+import random
+import einops
+from functools import partial
+import numpy as np
+import torch
+import datasets
+import os
+import re
+from torch import Tensor
+from torch.utils.data import DataLoader
+from datasets import load_dataset, concatenate_datasets
+from jaxtyping import Float, Int, Bool
+from typing import Dict, Iterable, List, Tuple, Union, Literal, Optional
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformer_lens import HookedTransformer
+from transformer_lens.utils import (
+    get_dataset,
+    tokenize_and_concatenate,
+    get_act_name,
+    get_attention_mask,
+    remove_batch_dim,
+    USE_DEFAULT_VALUE,
+    rprint,
+    test_prompt,
+)
+from transformer_lens.hook_points import HookPoint
+from tqdm.notebook import tqdm
+import pandas as pd
+from circuitsvis.activations import text_neuron_activations
+from circuitsvis.topk_samples import topk_samples
+from IPython.display import HTML, display
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from summarization_utils.patching_metrics import get_logit_diff
+from summarization_utils.tokenwise_ablation import (
+    compute_ablation_modified_loss,
+    load_directions,
+    get_random_directions,
+    get_zeroed_dir_vector,
+    get_layerwise_token_mean_activations,
+    ablation_hook_base,
+    AblationHook,
+    AblationHookIterator,
+    get_batch_token_mean_activations,
+    loss_fn,
+    DEFAULT_DEVICE,
+)
+from summarization_utils.datasets import (
+    OWTData,
+    PileFullData,
+    PileSplittedData,
+    HFData,
+    mask_positions,
+    construct_exclude_list,
+)
+from summarization_utils.neuroscope import plot_top_onesided
+from summarization_utils.store import ResultsFile, TensorBlockManager
+from summarization_utils.path_patching import act_patch, Node, IterNode, IterSeqPos
+from summarization_utils.toy_datasets import (
+    CounterfactualDataset,
+    ToyDeductionTemplate,
+    ToyBindingTemplate,
+    ToyProfilesTemplate,
+)
+from summarization_utils.counterfactual_patching import (
+    patch_by_position_group,
+    patch_at_position,
+    patch_by_layer,
+    plot_layer_results_per_batch,
+)
+
+# %%
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["CUDA_LAUNCH_BLOCKING"] = "1"
+os.environ["TORCH_USE_CUDA_DSA"] = "1"
+torch.set_grad_enabled(False)
+torch.manual_seed(0)
+random.seed(0)
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+
+# %%
+class HookedMistral(HookedTransformer):
+    def to_tokens(
+        self,
+        string: str | List[str],
+        prepend_bos=USE_DEFAULT_VALUE,
+        padding_side: Literal["left", "right"] | None = USE_DEFAULT_VALUE,
+        move_to_device: bool | None = True,
+        truncate: bool | None = True,
+        prepend_blank: bool = True,
+    ):
+        """Map a string to the ids for that string.
+
+        Handles the case of mistral which has an extra BOS-like token prepended to the start
+        of the output of tokenizer.encode().
+        """
+        if "mistral" not in self.cfg.model_name.lower() or not prepend_blank:
+            return super().to_tokens(
+                string,
+                prepend_bos=prepend_bos,
+                padding_side=padding_side,
+                move_to_device=move_to_device,
+                truncate=truncate,
+            )
+        if prepend_bos is USE_DEFAULT_VALUE:
+            prepend_bos = self.cfg.default_prepend_bos
+        if isinstance(string, str):
+            string = "_" + string
+        else:
+            string = ["_" + s for s in string]
+
+        tokens = super().to_tokens(
+            string,
+            prepend_bos=prepend_bos,
+            padding_side=padding_side,
+            move_to_device=move_to_device,
+            truncate=truncate,
+        )
+        # Remove the artificial token
+        if prepend_bos:
+            tokens = torch.cat((tokens[:, :1], tokens[:, 2:]), dim=1)
+        else:
+            tokens = tokens[:, 1:]
+        return tokens
+
+
+# %%
+model = HookedMistral.from_pretrained(
+    "mistral-7b-instruct",
+    torch_dtype=torch.bfloat16,
+    fold_ln=False,
+    center_writing_weights=False,
+    center_unembed=False,
+    device=device,
+)
+assert model.tokenizer is not None
+# %%
+# test_prompt(
+#     "[INST] Anne carried her cane, hat and glasses. Anne lost her cane on the walk. Anne found her cane again in some bushes. Question: Does Anne have her cane? Answer (Yes/No): [/INST]",
+#     " Yes",
+#     model,
+#     prepend_space_to_answer=False,
+# )
+# %%
+PROMPT_ANSWER_PAIRS = [
+    (
+        "[INST] Anne carried her stick, hat and glasses. Anne lost her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+        " No",
+    ),
+    (
+        "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+        " Yes",
+    ),
+    (
+        "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+        " Yes",
+    ),
+    (
+        "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+        " Yes",
+    ),
+    (
+        "[INST] Anne carried her stick, hat and glasses. Anne used her stick on the walk. Question: Does Anne have her stick? Answer (Yes/No): [/INST]",
+        " Yes",
+    ),
+    (
+        "[INST] Anne carried her stick, hat and glasses. Anne lost her hat on the walk. Question: Does Anne have her hat? Answer (Yes/No): [/INST]",
+        " No",
+    ),
+    (
+        "[INST] Anne carried her stick, hat and glasses. Anne lost her glasses on the walk. Question: Does Anne have her glasses? Answer (Yes/No): [/INST]",
+        " No",
+    ),
+]
+# %%
+# for prompt, answer in PROMPT_ANSWER_PAIRS:
+#     test_prompt(prompt, answer, model, prepend_space_to_answer=False)
+# %%
+DATA_TUPLES = [
+    (prompt, answer, cf_prompt, cf_answer)
+    for (prompt, answer), (cf_prompt, cf_answer) in itertools.combinations(
+        PROMPT_ANSWER_PAIRS, 2
+    )
+    if answer != cf_answer
+]
+# %%
+dataset = CounterfactualDataset.from_tuples(DATA_TUPLES, model)
+# %%
+dataset.check_lengths_match()
+# %%
+dataset.test_prompts(max_prompts=4, top_k=10)
+# %%
+all_logit_diffs, cf_logit_diffs = dataset.compute_logit_diffs()
+# %%
+print(f"Original mean: {all_logit_diffs.mean():.2f}")
+print(f"Counterfactual mean: {cf_logit_diffs.mean():.2f}")
+# %%
+assert (all_logit_diffs > 0).all()
+assert (cf_logit_diffs < 0).all()
+# %%
+print(len(dataset))
+# %%
+pos_layer_results = patch_by_layer(dataset)
+# %%
+plot_layer_results_per_batch(dataset, pos_layer_results)
+# %%


### PR DESCRIPTION
# Description

The key new experiment was run in toy_world_model.py, patching between different occurrences of the same token (the object or period token).

Changes to utils:

- Methods for patching by just position rather than position and layer
- Overloaded getitem to allow extracting subsets of counterfactual data
- Fixed padding argument

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
- [x] I have followed the style guide below

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

# Style guide
- My code follows the [Black](https://pypi.org/project/black/) format
- I have minimised type warnings from [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
- Cull any redundant and unused code
- Cache results of slow operations in as flexible of a format as possible, in a flat structure inside results/cache and the file name contains all necessary identifying information (such as model name and dataset used) to avoid accidental overwriting.
- Use intuitive abstractions, making clear the public entrypoints to a given class
- Function and variable names should be long enough to be descriptive


